### PR TITLE
[modified_delete_flag]

### DIFF
--- a/app/controllers/admins/cds_controller.rb
+++ b/app/controllers/admins/cds_controller.rb
@@ -1,6 +1,7 @@
 class Admins::CdsController < ApplicationController
   before_action :authenticate_admin!
-  
+  before_action :reject_show, only: :show
+
   def new
     @cd = Cd.new
     @disc = @cd.discs.build
@@ -13,7 +14,7 @@ class Admins::CdsController < ApplicationController
   end
 
   def index
-    @cds = Cd.all
+    @cds = Cd.where(is_deleted: false)
   end
 
   def edit
@@ -32,9 +33,10 @@ class Admins::CdsController < ApplicationController
     redirect_to admins_cds_path
   end
 
-  def destroy
-    cd= Cd.find(params[:id])
-    cd.destroy
+  def hide
+    cd = Cd.find(params[:id])
+    cd.is_deleted = 1
+    cd.save
     redirect_to admins_cds_path
   end
 
@@ -69,10 +71,12 @@ class Admins::CdsController < ApplicationController
 
   end
 
+  private
 
   def cd_params
     params.require(:cd).permit(:name, :artist, :price, :stock, :image, :description, :sale_status, :delete_flag, :artist_id, :label_id, :genre_id,
                         discs_attributes: [:id, :disc_number, :cd_id, :_destroy,
                         songs_attributes: [:id, :song_name, :song_number, :_destroy]])
   end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,17 @@ class ApplicationController < ActionController::Base
 	def configure_permitted_parameters
 		devise_parameter_sanitizer.permit(:sign_up, keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :address, :post_code, :telephone])
 	end
+
+	def reject_show
+    @cd = Cd.find(params[:id])
+      if @cd.is_deleted == true
+      	flash[:notice] = "無効なアクセスです。"
+      	if admin_signed_in?
+      		redirect_to admins_cds_path
+      	else
+      		redirect_to clients_cds_path
+      	end
+      end
+  	end
+
 end

--- a/app/controllers/clients/cds_controller.rb
+++ b/app/controllers/clients/cds_controller.rb
@@ -1,7 +1,8 @@
 class Clients::CdsController < ApplicationController
+  before_action :reject_show, only: :show
 
   def index
-  	@cds = Cd.all
+  	@cds = Cd.where(is_deleted: false)
     @genres = Genre.all
   end
 

--- a/app/controllers/clients/orders_controller.rb
+++ b/app/controllers/clients/orders_controller.rb
@@ -1,5 +1,7 @@
 class Clients::OrdersController < ApplicationController
 
+  before_action :reject_buy, only: :buy
+
   def index
     @orders = Order.where(client_id: current_client.id)
     @total_price = 0
@@ -13,7 +15,7 @@ class Clients::OrdersController < ApplicationController
     @item = OrderItem.find(params[:id])
   end
 
-  def buy 
+  def buy
     @client = Client.find(current_client.id)
     @order = Order.new
     items = Item.where(client_id: current_client.id)
@@ -65,7 +67,7 @@ class Clients::OrdersController < ApplicationController
 
     items.each do |i|
       if i.quantity > i.cd.stock
-        flash[:notice] = "カート投入中、他のお客様による同一商品の購入があったため、購入の処理を完了することができませんでした。#{i.cd.name}の在庫数が#{i.cd.stock}枚となっております。お手数ですが#{i.cd.stock}枚以下にご変更の後、再度ご注文をお願いいたします。"
+        flash[:notice] = "カート投入中、他のお客様による同一商品の購入があったため、購入の処理を完了することができませんでした。"
         redirect_to clients_items_path
         return
       end
@@ -100,4 +102,12 @@ class Clients::OrdersController < ApplicationController
   def order_params
     params.require(:order).permit(:payment, :client_id)
   end
+
+  def reject_buy
+    if Item.where(client_id: current_client.id).blank?
+      flash[:notice] = "カートに商品が入っておりません。"
+      redirect_to clients_items_path
+    end
+  end
+
 end

--- a/app/views/admins/cds/_editform.html.erb
+++ b/app/views/admins/cds/_editform.html.erb
@@ -41,4 +41,4 @@
     </div>
 <%= f.submit "更新", class:"btn btn-primary " %>
 <% end %>
-<%= link_to "削除", admins_cd_path, method: :delete, "data-confirm" => "本当に消しますか?" ,class: "btn btn-danger" %>
+<%= link_to "削除", admins_cd_hide_path, method: :post, "data-confirm" => "本当に消しますか?" ,class: "btn btn-danger" %>

--- a/app/views/clients/items/index.html.erb
+++ b/app/views/clients/items/index.html.erb
@@ -2,32 +2,33 @@
 
 <% if @items == [] %>
 
-	<%= "お客様のショッピングカートに商品はありません" %>
+	<%= "お客様のカートに商品はありません。" %>
 
-	<% else %>
+<% else %>
 
-		<table>
-			<tr>
-				<% total_price = 0 %>
-				<!-- sumに初期値の設定 -->
-				<% @items.each do |item| %>
-					<td rowspan="2"><%= attachment_image_tag item.cd, :image %></td>
-					<td><%= link_to item.cd.name, clients_cd_path(item.cd.id) %></td>
-					<td><%= form_for item, url: clients_item_path(item.id) do |f| %>
-						<%= f.number_field :quantity, value: item.quantity, required:true, min:"1"  %>
-						<%= f.submit "変更" %></td>
-					<% end %>
-				<% total_price += item.quantity * item.cd.price %>
-				<!-- total_priceを算出 -->
-			</tr>
-			<tr>
-				<td>価格：¥<%= (item.cd.price*1.08).floor %></td>
-				<td><%=link_to "削除", clients_item_path(item.id), method: :delete %></td>
-			</tr>
+	<table>
+		<tr>
+			<% total_price = 0 %>
+			<!-- sumに初期値の設定 -->
+			<% @items.each do |item| %>
+				<td rowspan="2"><%= attachment_image_tag item.cd, :image %></td>
+				<td><%= link_to item.cd.name, clients_cd_path(item.cd.id) %></td>
+				<td><%= form_for item, url: clients_item_path(item.id) do |f| %>
+					<%= f.number_field :quantity, value: item.quantity, required:true, min:"1"  %>
+					<%= f.submit "変更" %></td>
 				<% end %>
-		</table>
+			<% total_price += item.quantity * item.cd.price %>
+			<!-- total_priceを算出 -->
+		</tr>
+		<tr>
+			<td>価格：¥<%= (item.cd.price*1.08).floor %></td>
+			<td><%=link_to "削除", clients_item_path(item.id), method: :delete %></td>
+		</tr>
+			<% end %>
+	</table>
 
-		<% unless @itmes == [] %>
-			<p>小計(<%= @total_quantity %>点の商品):¥ <%= (total_price*1.08).floor %> | <%= link_to "購入手続きへ進む", clients_order_buy_path(current_client.id) %></p>
+	<% unless @itmes == [] %>
+		<p>小計(<%= @total_quantity %>点の商品):¥ <%= (total_price*1.08).floor %> | <%= link_to "購入手続きへ進む", clients_order_buy_path(current_client.id) %></p>
 	<% end %>
+	
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,10 +20,12 @@ Rails.application.routes.draw do
 
   namespace :admins do
     resources :clients, except: [:new, :create]
-    
+
+    post 'cds/:id/hide' => 'cds#hide', as: 'cd_hide'
     get 'cds/add' => 'cds#add', as: 'cd_add'
     post 'cds/add_info' => 'cds#add_info', as: 'cd_add_info'
-    resources :cds
+
+    resources :cds, except: [:destroy]
 
     resources :orders, only: [:index, :update]
   end
@@ -40,12 +42,7 @@ Rails.application.routes.draw do
     sessions: 'admins/sessions'
   }
   devise_scope :admin do
-    authenticated :admin do
       root :to => 'admins/cds#index'
-    end
-    unauthenticated :admin do
-      root :to => 'admins/sessions#new'
-    end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20190620105520_add_is_deleted_to_cds.rb
+++ b/db/migrate/20190620105520_add_is_deleted_to_cds.rb
@@ -1,0 +1,5 @@
+class AddIsDeletedToCds < ActiveRecord::Migration[5.2]
+  def change
+  	add_column :cds, :is_deleted, :boolean, :default => false
+  end
+end

--- a/db/migrate/20190620105604_remove_delete_flag_from_cds.rb
+++ b/db/migrate/20190620105604_remove_delete_flag_from_cds.rb
@@ -1,0 +1,5 @@
+class RemoveDeleteFlagFromCds < ActiveRecord::Migration[5.2]
+  def change
+  	remove_column :cds, :delete_flag
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_18_061106) do
+ActiveRecord::Schema.define(version: 2019_06_20_105604) do
 
   create_table "addresses", force: :cascade do |t|
     t.string "last_name", null: false
@@ -48,12 +48,12 @@ ActiveRecord::Schema.define(version: 2019_06_18_061106) do
     t.integer "price", null: false
     t.integer "stock", null: false
     t.integer "sale_status", null: false
-    t.integer "delete_flag", default: 0, null: false
     t.integer "artist_id", null: false
     t.integer "label_id"
     t.integer "genre_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_deleted", default: false
   end
 
   create_table "clients", force: :cascade do |t|


### PR DESCRIPTION
・cdテーブルのdelete_flagのカラムを消して、boolean型(true or false)のis_deletedのカラムを作成しました。
・上記のカラムを使ってcdの論理削除を実装。is_deletedはデフォルトでfalseにしてます。削除ボタンを押すことでこれをtrueに変更する処理をしました。CD一覧ページの表示のための@cd = CD.allをCD.whereでis_deletedがfalseのものだけ引っ張ってます。

・上記だけだとis_deletedがtrueのものでもshowページにいけてカートに商品が追加できてしまうので、before_action、reject_showを使ってshowページへのアクセス制限しました。
・アクセス制限つながりで、今までカートにアイテムが入ってない状態でもURLから購入画面にいけてしまうのを、before_action、reject_buyを使ってアクセスできないように変更しました。

長文でごめんなさい！ご確認お願いします！